### PR TITLE
Add comparison of null/nil safety and syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Help welcome, eg by filling in the entries with `?` `TODO` and `CHECKME`, correc
 | User defined operators | partial: opCall opSlice, opAssign etc | yes | -1 |
 | User defined attributes | yes | ? | ? |
 | RAII | yes (modulo caveats https://github.com/timotheecour/D_vs_nim/issues/27) | no, see: [RAII](https://forum.nim-lang.org/t/362/1) | 1 |
+| prevention of null dereferencing | <p>manual null checks required</p> <p>`null` pointers to class objects can exist. The only way to check for them is to remember to use `if (myObj is null)`. Lessening the impact of this, many built-in types, such as integers, arrays, maps, and struct objects, can never be `null` ([source](https://w0rp.com/blog/post/null-and-d-programming-language/)).</p> | <p>manual null checks required</p> <p>`nil` references and pointers can exist. The standard way to check for them is to remember to use `if myObj.isNil`. Lessening the impact of this, many built-in types can never be `nil`, including `seq`s. However, tables (which are like D’s maps) can be `nil`.</p> <p>Nim also has an experimental `notnil` feature that enables a [`not nil` type annotation](https://nim-lang.org/docs/manual.html#types-not-nil-annotation), e.g. `ref SomeObject not nil`, to ensure that a variable can never hold `nil`. However, it doesn’t seem to be well-supported. The `notnil` feature was made experimental [in 2018](https://github.com/nim-lang/Nim/blob/devel/changelogs/changelog_0_19_0.md#changes-affecting-backwards-compatibility), but in 2020 its [brief documentation](https://nim-lang.org/docs/manual.html#types-not-nil-annotation) is still in the wrong section of the manual, and it has at least one [open bug](https://github.com/nim-lang/Nim/issues/7248) that may let a `nil` dereference error happen with a `not nil` type. `not nil` types are also [not widely used](https://github.com/nim-lang/Nim/pull/3296#issuecomment-138483068) in the standard library even for procs that will never return `nil`, so users must make redundant assertions.</p> | ? |
 | **debugging** |
 | **maturity** |
 | stability | few breaking changes in each release | pre 1.0, new releases often make lots of break changes | 1 |
@@ -135,6 +136,7 @@ See also https://github.com/timotheecour/D_vs_nim/issues/11
 | increment | `i++` | `i+=1` or `inc(i)` |
 | concatenation | `~` | `&` |
 | empty statement | `{}` | `discard` |
+| null pointer | `null` | `nil` |
 | **syntax:parsing** |
 | alias | `alias T2=T;` | ?; template, see https://github.com/nim-lang/Nim/issues/7090 |
 | type alias | `alias T2=T;` | `type T2=T` |

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Help welcome, eg by filling in the entries with `?` `TODO` and `CHECKME`, correc
 | User defined operators | partial: opCall opSlice, opAssign etc | yes | -1 |
 | User defined attributes | yes | ? | ? |
 | RAII | yes (modulo caveats https://github.com/timotheecour/D_vs_nim/issues/27) | no, see: [RAII](https://forum.nim-lang.org/t/362/1) | 1 |
-| prevention of null dereferencing | <p>manual null checks required</p> <p>`null` pointers to class objects can exist. The only way to check for them is to remember to use `if (myObj is null)`. Lessening the impact of this, many built-in types, such as integers, arrays, maps, and struct objects, can never be `null` ([source](https://w0rp.com/blog/post/null-and-d-programming-language/)).</p> | <p>manual null checks required</p> <p>`nil` references and pointers can exist. The standard way to check for them is to remember to use `if myObj.isNil`. Lessening the impact of this, many built-in types can never be `nil`, including `seq`s. However, tables (which are like D’s maps) can be `nil`.</p> <p>Nim also has an experimental `notnil` feature that enables a [`not nil` type annotation](https://nim-lang.org/docs/manual.html#types-not-nil-annotation), e.g. `ref SomeObject not nil`, to ensure that a variable can never hold `nil`. However, it doesn’t seem to be well-supported. The `notnil` feature was made experimental [in 2018](https://github.com/nim-lang/Nim/blob/devel/changelogs/changelog_0_19_0.md#changes-affecting-backwards-compatibility), but in 2020 its [brief documentation](https://nim-lang.org/docs/manual.html#types-not-nil-annotation) is still in the wrong section of the manual, and it has at least one [open bug](https://github.com/nim-lang/Nim/issues/7248) that may let a `nil` dereference error happen with a `not nil` type. `not nil` types are also [not widely used](https://github.com/nim-lang/Nim/pull/3296#issuecomment-138483068) in the standard library even for procs that will never return `nil`, so users must make redundant assertions.</p> | ? |
+| prevention of null dereferencing | <p>manual null checks required</p> <p>`null` pointers to class objects can exist. The only way to check for them is to remember to use `if (myObj is null)`. Lessening the impact of this, many built-in types, such as integers, fixed-size arrays, maps, and struct objects, can never throw `null` dereference errors, either by not being `null` or by treating `null` values as empty values ([source](https://w0rp.com/blog/post/null-and-d-programming-language/)).</p> | <p>manual null checks required</p> <p>`nil` references and pointers can exist. The standard way to check for them is to remember to use `if myObj == nil` or `if myObj.isNil`. Lessening the impact of this, many built-in types can never be `nil`, including `seq`s. Only `ptr` and `ref` types (and `cstring`s) can be `nil`.</p> <p>Nim also has an experimental `notnil` feature that enables a [`not nil` type annotation](https://nim-lang.org/docs/manual.html#types-not-nil-annotation), e.g. `ref SomeObject not nil`, to ensure that a variable can never hold `nil`. This feature was made experimental [in 2018](https://github.com/nim-lang/Nim/blob/devel/changelogs/changelog_0_19_0.md#changes-affecting-backwards-compatibility).</p> | ? |
 | **debugging** |
 | **maturity** |
 | stability | few breaking changes in each release | pre 1.0, new releases often make lots of break changes | 1 |
@@ -137,6 +137,7 @@ See also https://github.com/timotheecour/D_vs_nim/issues/11
 | concatenation | `~` | `&` |
 | empty statement | `{}` | `discard` |
 | null pointer | `null` | `nil` |
+| checking for null | `if (myObj is null)` | `if myObj == nil` or `if myObj.isNil` |
 | **syntax:parsing** |
 | alias | `alias T2=T;` | ?; template, see https://github.com/nim-lang/Nim/issues/7090 |
 | type alias | `alias T2=T;` | `type T2=T` |
@@ -200,6 +201,7 @@ See also https://github.com/timotheecour/D_vs_nim/issues/11
 | static assert | `static assert(foo);` | `static: assert foo` |
 | **library** |
 | universal type conversion | a.to!T | no: https://github.com/nim-lang/Nim/issues/7430 |
+| option/maybe type | [`Nullable`](https://dlang.org/phobos/std_typecons.html#.Nullable) in `std.typecons` | [`Option`](https://nim-lang.org/docs/options.html) in the `options` module |
 | path append | a.buildPath(b) | a / b ; does right thing on windows; NOTE: if b is absolute, buildPath returns b unlike nim |
 | **cmd line** |
 | custom define | -version=foo | --define:foo or --define:foo=bar |


### PR DESCRIPTION
I researched these features because I was wondering if either language had a solution like Rust’s [`Option`](https://doc.rust-lang.org/std/option/). Neither language does.

I decided the comparison result was “?” because D is better by default because more of its built-in types are non-nullable, but Nim can be made safer than D if you put in the work of redefining everything using the experimental `not nil` type annotation.